### PR TITLE
Build sasl with liblogin

### DIFF
--- a/debian_patches_0009_sasldb.al.diff
+++ b/debian_patches_0009_sasldb.al.diff
@@ -1,0 +1,14 @@
+Author: Fabian Fagerholm <fabbe@debian.org>
+Description: Fix linking with libsasldb.a when saslauthd is built with sasldb
+support.
+--- a/saslauthd/configure.in
++++ b/saslauthd/configure.in
+@@ -77,7 +77,7 @@ if test "$authsasldb" != no; then
+   AC_DEFINE(AUTH_SASLDB,[],[Include SASLdb Support])
+   SASL_DB_PATH_CHECK()
+   SASL_DB_CHECK()
+-  SASL_DB_LIB="$SASL_DB_LIB ../sasldb/.libs/libsasldb.al"
++  SASL_DB_LIB="$SASL_DB_LIB ../sasldb/.libs/libsasldb.a"
+ fi
+ 
+ AC_ARG_ENABLE(httpform, [  --enable-httpform       enable HTTP form authentication [[no]] ],

--- a/debian_patches_0014_avoid_pic_overwrite.diff
+++ b/debian_patches_0014_avoid_pic_overwrite.diff
@@ -1,0 +1,27 @@
+Author: Fabian Fagerholm <fabbe@debian.org>
+Description: This patch makes sure the non-PIC version of libsasldb.a, which
+is created out of non-PIC objects, is not going to overwrite the PIC version,
+which is created out of PIC objects. The PIC version is placed in .libs, and
+the non-PIC version in the current directory.  This ensures that both non-PIC
+and PIC versions are available in the correct locations.
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -78,7 +78,7 @@ endif
+ 
+ libsasl2.a: libsasl2.la $(SASL_STATIC_OBJS)
+ 	@echo adding static plugins and dependencies
+-	$(AR) cru .libs/$@ $(SASL_STATIC_OBJS)
++	$(AR) cru $@ $(SASL_STATIC_OBJS)
+ 	@for i in ./libsasl2.la ../sasldb/libsasldb.la ../plugins/lib*.la; do \
+ 	if test ! -f $$i; then continue; fi; . $$i; \
+ 	for j in $$dependency_libs foo; do \
+--- a/sasldb/Makefile.am
++++ b/sasldb/Makefile.am
+@@ -63,6 +63,6 @@ libsasldb_a_SOURCES =
+ EXTRA_libsasldb_a_SOURCES =
+ 
+ libsasldb.a: libsasldb.la $(SASL_DB_BACKEND_STATIC)
+-	$(AR) cru .libs/$@ $(SASL_DB_BACKEND_STATIC)
++	$(AR) cru $@ $(SASL_DB_BACKEND_STATIC)
+ 
+ 

--- a/org.kde.kontact.json
+++ b/org.kde.kontact.json
@@ -74,6 +74,7 @@
                 "--enable-login",
                 "--with-plugindir=/app/lib/sasl2:/usr/lib/sasl2"
             ],
+            "no-parallel-make": true,
             "sources": [
                 {
                     "type": "archive",
@@ -89,9 +90,10 @@
                     "path": "debian_patches_0014_avoid_pic_overwrite.diff"
                 },
                 {
-                    "type": "script",
+                    "type": "shell",
                     "commands": [
-                        "rm aclocal.m4 config/libtool.m4"
+                        "cp /usr/share/automake-1.15/config.guess config",
+                        "cp /usr/share/automake-1.15/config.sub config"
                     ]
                 }
             ]

--- a/org.kde.kontact.json
+++ b/org.kde.kontact.json
@@ -60,6 +60,42 @@
     "rename-icon": "kontact",
     "copy-icon": true,
     "modules": [
+        {   "name": "cyrus-sasl2",
+            "config-opts": [
+                "--with-dblib=berkeley",
+                "--without-pam",
+                "--without-opie",
+                "--without-des",
+                "--disable-gssapi",
+                "--enable-cram",
+                "--enable-digest",
+                "--enable-otp",
+                "--enable-plain",
+                "--enable-login",
+                "--with-plugindir=/app/lib/sasl2:/usr/lib/sasl2"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-2.1.26.tar.gz",
+                    "sha256": "8fbc5136512b59bb793657f36fadda6359cae3b08f01fd16b3d406f1345b7bc3"
+                },
+                {
+                    "type": "patch",
+                    "path": "debian_patches_0009_sasldb.al.diff"
+                },
+                {
+                    "type": "patch",
+                    "path": "debian_patches_0014_avoid_pic_overwrite.diff"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "rm aclocal.m4 config/libtool.m4"
+                    ]
+                }
+            ]
+        },
         {
             "name": "gpgme",
             "sources": [


### PR DESCRIPTION
Update to use the same settings as the Freedesktop build scripts.
(Other than the path to libdb, which should just use
the version provided by the Freedesktop platform instead of whatever
"STAGING_DIR" was set to.)

Once plasma booted correctly, I was able to send email via office365 using 

```
flatpak-builder --run build-dir org.kde.kontact.json run_kontact.sh