### PR TITLE
Simplify sasl2 path now that the plain mechanism is provided by the f…

### DIFF
--- a/org.kde.kontact.json
+++ b/org.kde.kontact.json
@@ -72,7 +72,7 @@
                 "--enable-otp",
                 "--enable-plain",
                 "--enable-login",
-                "--with-plugindir=/app/lib/sasl2:/usr/lib/sasl2"
+                "--with-plugindir=/app/lib/sasl2"
             ],
             "no-parallel-make": true,
             "sources": [


### PR DESCRIPTION
…ramework

The newer platform provides the sasl2 plugin so we don't need the extra path, and honestly it led to an odd path in the app bundle.