### PR TITLE
Fix QtKeychain build

### DIFF
--- a/org.kde.kontact.json
+++ b/org.kde.kontact.json
@@ -114,6 +114,7 @@
         {
             "name": "qtkeychain",
             "buildsystem": "cmake-ninja",
+            "config-opts": [ "-DCMAKE_INSTALL_LIBDIR=/app/lib", "-DLIB_INSTALL_DIR=/app/lib" ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
It installs in /app/lib64 instead of /app/lib and then the app cannot find it.

I found out because I copied the snippet from Kontact into QGIS and then QGIS wasn't working ^^'