### PR TITLE
Fix desktop file export bypassing run_kontact.sh script

### DIFF
--- a/org.kde.kontact.json
+++ b/org.kde.kontact.json
@@ -69,6 +69,9 @@
         "*.a",
         "*.la"
     ],
+    "cleanup-commands": [
+        "sed -i -- 's/^Exec=\\(.*\\)$/Exec=/app/bin/run_kontact.sh \\1/' /app/share/applications/*.desktop /app/share/dbus-1/services/*.service"
+    ],
     "copy-icon": true,
     "modules": [
         {


### PR DESCRIPTION
If a fresh install was first executed via CLI and later with the desktop file it would seem like all data is gone because a different Akonadi instance would be used due to missing AKONADI_INSTANCE=flatpak export.

Fixes #273